### PR TITLE
Add python 3.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,27 +6,24 @@ version: 2
 
 
 jobs:
-  test:
+  test35:
     docker:
-      - image: python:3.6
-
-    steps:
+      - image: python:3.5
+    steps: &test_steps
       - checkout
-
       - run:
           name: install tox
           command: |
             pip install tox
-
       - run:
           name: tox -r to install and run tests and flake
           command: |
-            tox -r
+            tox -r --skip-missing-interpreters
 
-  publish:
+  publish35:
     docker:
-      - image: python:3.6
-    steps:
+      - image: python:3.5
+    steps: &publish_steps
       - checkout
       - run:
           name: set PyPI creds in .pypirc
@@ -46,11 +43,22 @@ jobs:
           name: publish
           command: twine upload dist/*
 
+  test36:
+    docker:
+      - image: python:3.6
+    steps: *test_steps
+
+  publish36:
+    docker:
+      - image: python:3.6
+    steps: *publish_steps
+
 workflows:
   version: 2
   test_and_publish:
     jobs:
-      - test
+      - test35
+      - test36
       - approve_publish:
           type: approval
           requires:
@@ -58,10 +66,11 @@ workflows:
           filters:
             branches:
               only: master
-      - publish:
+      - publish35:
           context: pypi
           requires:
             - approve_publish
-          filters:
-            branches:
-              only: master
+      - publish36:
+          context: pypi
+          requires:
+            - approve_publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - checkout
       - run:
           name: install tox
-          command:             pip install tox
+          command: pip install tox
       - run:
           name: tox -r to install and run tests and flake (python 3.6 only)
           command: tox -r -e py36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,14 @@ jobs:
   test35:
     docker:
       - image: python:3.5
-    steps: &test_steps
+    steps:
       - checkout
       - run:
           name: install tox
-          command: |
-            pip install tox
+          command: pip install tox
       - run:
-          name: tox -r to install and run tests and flake
-          command: |
-            tox -r --skip-missing-interpreters
+          name: tox -r to install and run tests and flake (python 3.5 only)
+          command: tox -r -e py35
 
   publish35:
     docker:
@@ -46,7 +44,14 @@ jobs:
   test36:
     docker:
       - image: python:3.6
-    steps: *test_steps
+    steps:
+      - checkout
+      - run:
+          name: install tox
+          command:             pip install tox
+      - run:
+          name: tox -r to install and run tests and flake (python 3.6 only)
+          command: tox -r -e py36
 
   publish36:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,8 @@ workflows:
       - approve_publish:
           type: approval
           requires:
-            - test
+            - test35
+            - test36
           filters:
             branches:
               only: master

--- a/picamraw/main.py
+++ b/picamraw/main.py
@@ -108,7 +108,8 @@ def extract_raw_from_jpeg(filepath, camera_version, sensor_mode):
 def _guard_attribute_is_a_multiple_of(attribute_name, attribute_value, multiple):
     if not attribute_value % multiple == 0:
         raise ValueError(
-            f'Incoming data is the wrong shape: {attribute_name} ({attribute_value}) is not a multiple of {multiple}'
+            'Incoming data is the wrong shape: {attribute_name} ({attribute_value}) is not a multiple of {multiple}'
+            .format(**locals())
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description_content_type='text/markdown',
     url='https://www.github.com/osmosystems/picamraw',
     packages=find_packages(),
-    python_requires='~=3.6',
+    python_requires='~=3.5',
     install_requires=[
         'numpy',
     ],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ patch_version = os.environ.get('PATCH_VERSION', '0')
 
 setup(
     name='picamraw',
-    version=f'1.1.{patch_version}',
+    version='1.1.{patch_version}'.format(**locals()),
     author='Osmo Systems',
     author_email='dev@osmobot.com',
     description='Library for extracting raw bayer data from a Raspberry Pi JPEG+RAW file',

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # Set skispdist and usedevelop to avoid making an sdist but still install package locally.
 
 [tox]
-envlist=py36
+envlist=py35,py36
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
because the downvote on https://raspberrypi.stackexchange.com/a/91580/93261 has a point!

tricky part was setting up CircleCI to (hopefully) publish both python 3.5 and 3.6 versions with a single approval step.